### PR TITLE
Replace ConvertDdsImageToArray() with ConvertFromDdsArray().

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ fixed (byte* ptr = span)
     DirectXTexSharp.Texconv.ConvertAndSaveDdsImage(ptr, len, newpath, filetype, false, false);
 
     // test buffer saving
-    var buffer = DirectXTexSharp.Texconv.ConvertDdsImageToArray(ptr, len, filetype, false, false);
+    var buffer = DirectXTexSharp.Texconv.ConvertFromDdsArray(ptr, len, filetype, false, false);
     var newpath2 = Path.Combine(outDir, $"{fileName}.2.{extension}");
     File.WriteAllBytes(newpath2, buffer);
 


### PR DESCRIPTION
Purpose
---------
Update the README.md to correct the example code snippet.

ConvertDdsImageToArray() does not exist in v0.3.0 NuGet of DirectXTexSharp.  It appears to have been replaced by ConvertFromDdsArray() which performs the same functionality.  

A working example of a test app which utilizes the DirectXTexSharp NuGet and an updated version of the example code snippet can be found here: 
https://github.com/gammaparticle/DirectXTexSharpApp/blob/main/DirectXTexSharpApp/Client.cs

Note: Some DDS -> <image format> conversions, for example DDS -> PNG, result in TIFF instead of the requested file format.