### PR TITLE
Issue3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -407,6 +407,9 @@ FodyWeavers.xsd
 !.vscode/extensions.json
 *.code-workspace
 
+# Other VS files
+*.vcxproj
+
 # Local History for Visual Studio Code
 .history/
 

--- a/DirectXTexSharp/Image.h
+++ b/DirectXTexSharp/Image.h
@@ -22,15 +22,15 @@ namespace DirectXTexSharp {
         //Image(DirectX::Image* image);
         Image(DirectX::Image& image);
 
-        property int width {
+        property std::size_t width {
         	public:
-        		int get() {
+        		std::size_t get() {
         			return m_instance_->width;
         		}
         	}
-        property int height {
+        property std::size_t height {
         	public:
-        		int get() {
+        		std::size_t get() {
         		return m_instance_->height;
         		}
         	}
@@ -40,15 +40,15 @@ namespace DirectXTexSharp {
         		return static_cast<DirectXTexSharp::DXGI_FORMAT_WRAPPED>(m_instance_->format);
         		}
         	}
-        property int rowPitch {
+        property std::size_t rowPitch {
         	public:
-        		int get() {
+        		std::size_t get() {
         			return m_instance_->rowPitch;
         		}
         	}
-        property int slicePitch {
+        property std::size_t slicePitch {
         	public:
-        		int get() {
+        		std::size_t get() {
         			return m_instance_->slicePitch;
         		}
         	}

--- a/DirectXTexSharp/ScratchImage.cpp
+++ b/DirectXTexSharp/ScratchImage.cpp
@@ -23,7 +23,7 @@ array<byte>^ ScratchImage::GetPixels()
 	auto dataSize = this->GetPixelsSize();
 	auto ptr = m_instance_->GetPixels();
 
-	array<byte>^ _Data = gcnew array<byte>(dataSize);
+	array<byte>^ _Data = gcnew array<byte>(int(dataSize));
 
 	for (int i = 0; i < _Data->Length; ++i)
 		_Data[i] = ptr[i];
@@ -31,7 +31,7 @@ array<byte>^ ScratchImage::GetPixels()
 	return _Data;
 }
 
-int ScratchImage::GetPixelsSize()
+std::size_t ScratchImage::GetPixelsSize()
 {
 	return m_instance_->GetPixelsSize();
 }
@@ -43,7 +43,7 @@ Image^ ScratchImage::GetImages()
 	return gcnew DirectXTexSharp::Image(*native_image_ptr);
 }
 
-int DirectXTexSharp::ScratchImage::GetImageCount()
+std::size_t DirectXTexSharp::ScratchImage::GetImageCount()
 {
 	return m_instance_->GetImageCount();
 }

--- a/DirectXTexSharp/ScratchImage.h
+++ b/DirectXTexSharp/ScratchImage.h
@@ -62,10 +62,10 @@ namespace DirectXTexSharp {
 	        TexMetadata^ GetMetadata();
 
             array<byte>^ GetPixels();
-	        int GetPixelsSize();
+	        std::size_t GetPixelsSize();
 
 	        Image^ GetImages();
-            int GetImageCount();
+            std::size_t GetImageCount();
 
 	};
 }

--- a/DirectXTexSharp/TexMetadata.h
+++ b/DirectXTexSharp/TexMetadata.h
@@ -40,62 +40,62 @@ namespace DirectXTexSharp {
 			TexMetadata();
 			TexMetadata(DirectX::TexMetadata& metadata);
 
-    	property int width {
+    	property std::size_t width {
     		public:
-    		int get() {
+    		std::size_t get() {
 	            return m_instance_->width;
 	        }
 	    }
-	    property int height {
+	    property std::size_t height {
 			public:
-	        int get() {
+	        std::size_t get() {
 	            return m_instance_->height;
 	        }
-	        }
-	    property int depth {
+	    }
+	    property std::size_t depth {
 			public:
-	        int get() {
+	        std::size_t get() {
 	            return m_instance_->depth;
 	        }
-	        }
-	    property int arraySize {
+	    }
+	    property std::size_t arraySize {
 			public:
-	        int get() {
+	        std::size_t get() {
 	            return m_instance_->arraySize;
 	        }
-	        }
-	    property int mipLevels {
+	    }
+	    property std::size_t mipLevels {
 			public:
-	        int get() {
+	        std::size_t get() {
 	            return m_instance_->mipLevels;
 	        }
-	        }
+	    }
 	    property UINT32 miscFlags {
 			public:
 	        UINT32 get() {
 	            return m_instance_->miscFlags;
 	        }
-	        }
+	    }
 	    property UINT32 miscFlags2 {
 			public:
 	        UINT32 get() {
 	            return m_instance_->miscFlags2;
 	        }
-	        }
+	    }
 	    property DirectXTexSharp::DXGI_FORMAT_WRAPPED format {
 			public:
 				DirectXTexSharp::DXGI_FORMAT_WRAPPED get() {
-	            return static_cast<DirectXTexSharp::DXGI_FORMAT_WRAPPED>(m_instance_->format);
+					return static_cast<DirectXTexSharp::DXGI_FORMAT_WRAPPED>(m_instance_->format);
 				}
 				void set(DirectXTexSharp::DXGI_FORMAT_WRAPPED value) {
 					m_instance_->format = static_cast<DXGI_FORMAT>(value);
 				}
-	        }
+	    }
 	    property DirectXTexSharp::TEX_DIMENSION dimension {
 			public:
 				DirectXTexSharp::TEX_DIMENSION get() {
-	            return static_cast<DirectXTexSharp::TEX_DIMENSION>(m_instance_->dimension);
-	        }
+					return static_cast<DirectXTexSharp::TEX_DIMENSION>(m_instance_->dimension);
+				}
         }
     };
 }

--- a/DirectXTexSharp/Texconv.cpp
+++ b/DirectXTexSharp/Texconv.cpp
@@ -152,7 +152,7 @@ int DirectXTexSharp::Texconv::ConvertAndSaveDdsImage(
     }
     case DirectXTexSharp::ESaveFileTypes::PNG:
     {
-        DirectX::WICCodecs codec = DirectX::WICCodecs::WIC_CODEC_TIFF;
+        DirectX::WICCodecs codec = DirectX::WICCodecs::WIC_CODEC_PNG;
         size_t nimages = 1;
 
         hr = DirectX::SaveToWICFile(
@@ -167,7 +167,7 @@ int DirectXTexSharp::Texconv::ConvertAndSaveDdsImage(
     }
     case DirectXTexSharp::ESaveFileTypes::BMP:
     {
-        DirectX::WICCodecs codec = DirectX::WICCodecs::WIC_CODEC_TIFF;
+        DirectX::WICCodecs codec = DirectX::WICCodecs::WIC_CODEC_BMP;
         size_t nimages = 1;
 
         hr = DirectX::SaveToWICFile(
@@ -185,7 +185,7 @@ int DirectXTexSharp::Texconv::ConvertAndSaveDdsImage(
 
     if (FAILED(hr))
     {
-        wprintf(L"Failed to initialize COM (%08X%ls)\n", static_cast<unsigned int>(hr));
+        wprintf(L"Failed to initialize COM (%08X%ls)\n", static_cast<unsigned int>(hr), L"hr");
         return 1;
     }
 
@@ -258,7 +258,7 @@ array<System::Byte>^ DirectXTexSharp::Texconv::ConvertFromDdsArray(
     }
     case DirectXTexSharp::ESaveFileTypes::PNG:
     {
-        DirectX::WICCodecs codec = DirectX::WICCodecs::WIC_CODEC_TIFF;
+        DirectX::WICCodecs codec = DirectX::WICCodecs::WIC_CODEC_PNG;
         size_t nimages = 1;
 
         hr = DirectX::SaveToWICMemory(
@@ -273,7 +273,7 @@ array<System::Byte>^ DirectXTexSharp::Texconv::ConvertFromDdsArray(
     }
     case DirectXTexSharp::ESaveFileTypes::BMP:
     {
-        DirectX::WICCodecs codec = DirectX::WICCodecs::WIC_CODEC_TIFF;
+        DirectX::WICCodecs codec = DirectX::WICCodecs::WIC_CODEC_BMP;
         size_t nimages = 1;
 
         hr = DirectX::SaveToWICMemory(
@@ -291,14 +291,14 @@ array<System::Byte>^ DirectXTexSharp::Texconv::ConvertFromDdsArray(
 
     if (FAILED(hr))
     {
-        wprintf(L"Failed to initialize COM (%08X%ls)\n", static_cast<unsigned int>(hr));
+        wprintf(L"Failed to initialize COM (%08X%ls)\n", static_cast<unsigned int>(hr), L"hr");
         System::Runtime::InteropServices::Marshal::ThrowExceptionForHR(hr);
     }
 
     // copy buffer
     auto len_buffer = blob.GetBufferSize();
     auto buffer = static_cast<uint8_t*>(blob.GetBufferPointer());
-    array<byte>^ _Data = gcnew array<byte>(len_buffer);
+    array<byte>^ _Data = gcnew array<byte>(int(len_buffer));
 
     for (int i = 0; i < _Data->Length; ++i)
         _Data[i] = buffer[i];
@@ -321,7 +321,7 @@ array<System::Byte>^ DirectXTexSharp::Texconv::ConvertToDdsArray(
     //copy buffer
     auto len_buffer = blob.GetBufferSize();
     auto buffer = static_cast<uint8_t*>(blob.GetBufferPointer());
-    array<byte>^ _Data = gcnew array<byte>(len_buffer);
+    array<byte>^ _Data = gcnew array<byte>(int(len_buffer));
 
     for (int i = 0; i < _Data->Length; ++i)
         _Data[i] = buffer[i];
@@ -359,7 +359,7 @@ std::unique_ptr<DirectX::ScratchImage> DirectXTexSharp::Texconv::ConvertFromDdsM
     hr = DirectX::LoadFromDDSMemory(bytePtr, len, ddsFlags, &info, *image);
     if (FAILED(hr))
     {
-        wprintf(L" FAILED (%08X%ls)\n", static_cast<unsigned int>(hr));
+        wprintf(L" FAILED (%08X%ls)\n", static_cast<unsigned int>(hr), L"hr");
         System::Runtime::InteropServices::Marshal::ThrowExceptionForHR(hr);
     }
 
@@ -391,7 +391,7 @@ std::unique_ptr<DirectX::ScratchImage> DirectXTexSharp::Texconv::ConvertFromDdsM
         auto hr = DirectX::Decompress(img, nimg, info, DXGI_FORMAT_UNKNOWN /* picks good default */, *timage);
         if (FAILED(hr))
         {
-            wprintf(L" FAILED [decompress] (%08X%ls)\n", static_cast<unsigned int>(hr));
+            wprintf(L" FAILED [decompress] (%08X%ls)\n", static_cast<unsigned int>(hr), L"hr");
             System::Runtime::InteropServices::Marshal::ThrowExceptionForHR(hr);
         }
 
@@ -434,7 +434,7 @@ std::unique_ptr<DirectX::ScratchImage> DirectXTexSharp::Texconv::ConvertFromDdsM
         auto hr = FlipRotate(image->GetImages(), image->GetImageCount(), image->GetMetadata(), dwFlags, *timage);
         if (FAILED(hr))
         {
-            wprintf(L" FAILED [fliprotate] (%08X%ls)\n", static_cast<unsigned int>(hr));
+            wprintf(L" FAILED [fliprotate] (%08X%ls)\n", static_cast<unsigned int>(hr), L"hr");
             System::Runtime::InteropServices::Marshal::ThrowExceptionForHR(hr);
         }
 
@@ -487,7 +487,7 @@ std::unique_ptr<DirectX::ScratchImage> DirectXTexSharp::Texconv::ConvertFromDdsM
             dwFilter | dwFilterOpts | dwSRGB | dwConvert, alphaThreshold, *timage);
         if (FAILED(hr))
         {
-            wprintf(L" FAILED [convert] (%08X%ls)\n", static_cast<unsigned int>(hr));
+            wprintf(L" FAILED [convert] (%08X%ls)\n", static_cast<unsigned int>(hr), L"hr");
             System::Runtime::InteropServices::Marshal::ThrowExceptionForHR(hr);
         }
 
@@ -1089,7 +1089,7 @@ DirectX::Blob DirectXTexSharp::Texconv::ConvertToDdsMemory(
 
     if (FAILED(hr))
     {
-        wprintf(L"Failed to initialize COM (%08X%ls)\n", static_cast<unsigned int>(hr));
+        wprintf(L"Failed to initialize COM (%08X%ls)\n", static_cast<unsigned int>(hr), L"hr");
         System::Runtime::InteropServices::Marshal::ThrowExceptionForHR(hr);
     }
 


### PR DESCRIPTION
Resolves Issue #3 

WIC_CODEC_TIFF was used to create both PNG and BMP files instead of WIC_CODEC_PNG and WIC_CODEC_BMP respectively. In addition: size_t to int and wprintf() warnings were fixed.  JPEG filetype format was already correct.  TIFF data displayed in their files denotes the original image had been TIFF and then converted to JPEG.

Below displays correct file types for generated PNG and BMP files.
![ResolvedFileTypes](https://user-images.githubusercontent.com/575507/130336688-c1b4b228-bd1d-40ab-86ab-d374080e4252.png)

Changes should fix the same filetype bug in WolvenKit.CLI where, for example, BMP files generated from uncook are TIFF files with .bmp extensions.